### PR TITLE
Prevent OutOfMemoryError in graaldocker doc

### DIFF
--- a/src/main/docs/guide/graal/graaldocker.adoc
+++ b/src/main/docs/guide/graal/graaldocker.adoc
@@ -1,1 +1,5 @@
 include::{commondir}/common-graal-docker.adoc[]
+
+### Preventing java.lang.OutOfMemoryError errors
+
+When I tried to compile a `native-image` for `GraalVM` using a `Dockerfile`, I realised it took a long time to process, until it finally blew up with a `java.lang.OutOfMemoryError`. From what I understand, it is likely the case that the Docker engine doesn't have enough *memory* as resource to use in order to complete this compilation. By default, it comes with *2GB*; which, reading through stackoverflow, is not enough. Setting it from *9GB* to *12GB* solved it for me.


### PR DESCRIPTION
Hello!

(My very first attempt to commit in open-source)

I followed this very well-structured tutorial of the awesome Micronaut, however I stumbled upon an issue which might have been because of my lack of knowledge. But nonetheless, given that this is a basic tutorial I think that this addition would make sense for engineers like less knowledge.

Many thanks :)