### PR TITLE
Fix deprecated @MicronautTest annotation

### DIFF
--- a/complete/src/test/java/example/micronaut/HelloControllerTest.java
+++ b/complete/src/test/java/example/micronaut/HelloControllerTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.RxHttpClient;
 import io.micronaut.http.client.annotation.Client;
-import io.micronaut.test.annotation.MicronautTest;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;


### PR DESCRIPTION
**Motivation:** 
After cloning the create your first Micronaut app repository, I noticed a deprecation warning for the following annotation `import io.micronaut.test.annotation.MicronautTest;` inside `HelloControllerTest.java`

The documentation contained the following message:
```
Deprecated
since 1.3, use the concrete implementations (eg:
io.micronaut.test.extensions.junit5.annotation.MicronautTest
, etc)
```

**Modification:**
Changed the `import io.micronaut.test.annotation.MicronautTest;` annotation with `io.micronaut.test.extensions.junit5.annotation.MicronautTest`.

**Results:**
No more deprecation warning.